### PR TITLE
lib/wallet: add delete tx support to the CLI and JS clients

### DIFF
--- a/bin/hsw-cli
+++ b/bin/hsw-cli
@@ -363,6 +363,13 @@ class CLI {
     this.log(details);
   }
 
+  async deleteTX() {
+    const hash = this.config.str(0);
+    const deletion = await this.wallet.deleteTX(hash);
+
+    this.log(deletion);
+  }
+
   async getWalletBlocks() {
     const blocks = await this.wallet.getBlocks();
     this.log(blocks);
@@ -560,6 +567,9 @@ class CLI {
         break;
       case 'tx':
         await this.getDetails();
+        break;
+      case 'deletetx':
+        await this.deleteTX();
         break;
       case 'blocks':
         await this.getWalletBlocks();

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -284,6 +284,17 @@ class WalletClient extends Client {
   }
 
   /**
+   * Abandon single pending transaction. Confirmed
+   * transactions will throw an error. "TX not eligible"
+   * @param {Hash} hash
+   * @returns {Promise}
+   */
+
+  deleteTX(id, hash) {
+    return this.del(`/wallet/${id}/tx/${hash}`);
+  }
+
+  /**
    * Get wallet blocks.
    * @param {Number} height
    * @returns {Promise}
@@ -717,6 +728,17 @@ class Wallet extends EventEmitter {
 
   getTX(hash) {
     return this.client.getTX(this.id, hash);
+  }
+
+  /**
+   * Abandon single pending transaction. Confirmed
+   * transactions will throw an error. "TX not eligible"
+   * @param {Hash} hash
+   * @returns {Promise}
+   */
+
+  deleteTX(hash) {
+    return this.client.deleteTX(this.id, hash);
   }
 
   /**


### PR DESCRIPTION
## Summary

Currently, the client [does not support](https://handshake-org.github.io/api-docs/#delete-transaction) deleting transactions in the javascript wallet client or CLI.  We wanted this feature, so I implemented it in our fork of `hs-client`. Dropping this PR here if y'all think it's useful for others to have.