### PR TITLE
wallet client: remove create nested address

### DIFF
--- a/bin/hsw-cli
+++ b/bin/hsw-cli
@@ -184,13 +184,6 @@ class CLI {
     this.log(addr);
   }
 
-  async createNested() {
-    const account = this.config.str([0, 'account']);
-    const addr = await this.wallet.createNested(account);
-
-    this.log(addr);
-  }
-
   async getAccounts() {
     const accounts = await this.wallet.getAccounts();
     this.log(accounts);
@@ -540,9 +533,6 @@ class CLI {
       case 'change':
         await this.createChange();
         break;
-      case 'nested':
-        await this.createNested();
-        break;
       case 'retoken':
         await this.retoken();
         break;
@@ -611,7 +601,6 @@ class CLI {
         this.log('  $ account get [account-name]: Get account details.');
         this.log('  $ address: Derive new address.');
         this.log('  $ change: Derive new change address.');
-        this.log('  $ nested: Derive new nested address.');
         this.log('  $ retoken: Create new api key.');
         this.log('  $ send [address] [value]: Send transaction.');
         this.log('  $ mktx [address] [value]: Create transaction.');

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -426,16 +426,6 @@ class WalletClient extends Client {
   }
 
   /**
-   * Create nested address.
-   * @param {Object} options
-   * @returns {Promise}
-   */
-
-  createNested(id, account) {
-    return this.post(`/wallet/${id}/nested`, { account });
-  }
-
-  /**
    * Change or set master key`s passphrase.
    * @param {String|Buffer} passphrase
    * @param {(String|Buffer)?} old
@@ -859,16 +849,6 @@ class Wallet extends EventEmitter {
 
   createChange(account) {
     return this.client.createChange(this.id, account);
-  }
-
-  /**
-   * Create nested address.
-   * @param {Object} options
-   * @returns {Promise}
-   */
-
-  createNested(account) {
-    return this.client.createNested(this.id, account);
   }
 
   /**


### PR DESCRIPTION
This PR removes the `WalletClient.createNested` method along with `wallet.createNested`. It also removes mention of the method from the wallet CLI docs and the wallet CLI itself.

The `hsd` wallet does not have a route `POST /wallet/${id}/nested` and there are no "legacy" addresses yet, so this functionality can be safely removed.