### PR TITLE
wallet: add auction http wrappers

### DIFF
--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -316,6 +316,18 @@ class WalletClient extends Client {
   }
 
   /**
+   * Get name state for the given name.
+   * {@see hsd.NameState}
+   * @param {String} id
+   * @param {String} name
+   * @returns {Promise}
+   */
+
+  getName(id, name) {
+    return this.get(`/wallet/${id}/name/${name}`);
+  }
+
+  /**
    * @param {Number} now - Current time.
    * @param {Number} age - Age delta.
    * @returns {Promise}
@@ -749,6 +761,17 @@ class Wallet extends EventEmitter {
 
   getCoin(hash, index) {
     return this.client.getCoin(this.id, hash, index);
+  }
+
+  /**
+   * Get name state for the given name.
+   * {@see hsd.NameState}
+   * @param {String} name
+   * @returns {Promise}
+   */
+
+  getName(name) {
+    return this.client.getName(this.id, name);
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -572,6 +572,17 @@ class WalletClient extends Client {
   }
 
   /**
+   * Create finalize transaction.
+   * @param {String} id
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createFinalize(id, options) {
+    return this.post(`/wallet/${id}/finalize`, options);
+  }
+
+  /**
    * Sign a transaction.
    * @param {Object} options
    * @returns {Promise}
@@ -1211,6 +1222,16 @@ class Wallet extends EventEmitter {
 
   createCancel(options) {
     return this.client.createCancel(this.id, options);
+  }
+
+  /**
+   * Create finalize transaction.
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createFinalize(options) {
+    return this.client.createFinalize(this.id, options);
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -384,6 +384,20 @@ class WalletClient extends Client {
   }
 
   /**
+   * Get bids for all names.
+   * the wallet manages.
+   * {@see hsd.BlindBid}
+   * @param {String} id
+   * @param {Object?} options
+   * @param {Boolean?} options.own
+   * @returns {Promise}
+   */
+
+  getBids(id, options) {
+    return this.get(`/wallet/${id}/bid`, options);
+  }
+
+  /**
    * @param {Number} now - Current time.
    * @param {Number} age - Age delta.
    * @returns {Promise}
@@ -880,6 +894,19 @@ class Wallet extends EventEmitter {
 
   getBidsByName(name, options) {
     return this.client.getBidsByName(this.id, name, options);
+  }
+
+  /**
+   * Get bids for all names.
+   * the wallet manages.
+   * {@see hsd.BlindBid}
+   * @param {Object?} options
+   * @param {Boolean?} options.own
+   * @returns {Promise}
+   */
+
+  getBids(options) {
+    return this.client.getBids(this.id, options);
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -412,6 +412,20 @@ class WalletClient extends Client {
   }
 
   /**
+   * Get wallet reveals for all names
+   * the wallet manages.
+   * {@see hsd.BidReveal}
+   * @param {String} id
+   * @param {Object?} options
+   * @param {Boolean?} options.own
+   * @returns {Promise}
+   */
+
+  getReveals(id, options) {
+    return this.get(`/wallet/${id}/reveal`, options);
+  }
+
+  /**
    * @param {Number} now - Current time.
    * @param {Number} age - Age delta.
    * @returns {Promise}
@@ -934,6 +948,19 @@ class Wallet extends EventEmitter {
 
   getRevealsByName(name, options) {
     return this.client.getRevealsByName(this.id, name, options);
+  }
+
+  /**
+   * Get wallet reveals for all names
+   * the wallet manages.
+   * {@see hsd.BidReveal}
+   * @param {Object?} options
+   * @param {Boolean?} options.own
+   * @returns {Promise}
+   */
+
+  getReveals(options) {
+    return this.client.getReveals(this.id, options);
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -495,6 +495,17 @@ class WalletClient extends Client {
   }
 
   /**
+   * Create bid transaction.
+   * @param {String} id
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createBid(id, options) {
+    return this.post(`/wallet/${id}/bid`, options);
+  }
+
+  /**
    * Sign a transaction.
    * @param {Object} options
    * @returns {Promise}
@@ -1064,6 +1075,16 @@ class Wallet extends EventEmitter {
 
   createOpen(options) {
     return this.client.createOpen(this.id, options);
+  }
+
+  /**
+   * Create bid transaction.
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createBid(options) {
+    return this.client.createBid(this.id, options);
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -550,6 +550,17 @@ class WalletClient extends Client {
   }
 
   /**
+   * Create transfer transaction.
+   * @param {String} id
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createTransfer(id, options) {
+    return this.post(`/wallet/${id}/transfer`, options);
+  }
+
+  /**
    * Sign a transaction.
    * @param {Object} options
    * @returns {Promise}
@@ -1169,6 +1180,16 @@ class Wallet extends EventEmitter {
 
   createRenewal(options) {
     return this.client.createRenewal(this.id, options);
+  }
+
+  /**
+   * Create transfer transaction.
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createTransfer(options) {
+    return this.client.createTransfer(this.id, options);
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -583,6 +583,17 @@ class WalletClient extends Client {
   }
 
   /**
+   * Create revoke transaction.
+   * @param {String} id
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createRevoke(id, options) {
+    return this.post(`/wallet/${id}/revoke`, options);
+  }
+
+  /**
    * Sign a transaction.
    * @param {Object} options
    * @returns {Promise}
@@ -1232,6 +1243,16 @@ class Wallet extends EventEmitter {
 
   createFinalize(options) {
     return this.client.createFinalize(this.id, options);
+  }
+
+  /**
+   * Create revoke transaction.
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createRevoke(options) {
+    return this.client.createRevoke(this.id, options);
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -426,6 +426,18 @@ class WalletClient extends Client {
   }
 
   /**
+   * Get name resource.
+   * {@see hsd.Resource}
+   * @param {String} id
+   * @param {String} name
+   * @returns {Promise}
+   */
+
+  getResource(id, name) {
+    return this.get(`/wallet/${id}/resource/${name}`);
+  }
+
+  /**
    * @param {Number} now - Current time.
    * @param {Number} age - Age delta.
    * @returns {Promise}
@@ -961,6 +973,17 @@ class Wallet extends EventEmitter {
 
   getReveals(options) {
     return this.client.getReveals(this.id, options);
+  }
+
+  /**
+   * Get name resource.
+   * {@see hsd.Resource}
+   * @param {String} name
+   * @returns {Promise}
+   */
+
+  getResource(name) {
+    return this.client.getResource(this.id, name);
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -398,6 +398,20 @@ class WalletClient extends Client {
   }
 
   /**
+   * Get wallet reveal for a given name.
+   * {@see hsd.BidReveal}
+   * @param {String} id
+   * @param {String?} name
+   * @param {Object?} options
+   * @param {Boolean?} options.own
+   * @returns {Promise}
+   */
+
+  getRevealsByName(id, name, options) {
+    return this.get(`/wallet/${id}/reveal/${name}`, options);
+  }
+
+  /**
    * @param {Number} now - Current time.
    * @param {Number} age - Age delta.
    * @returns {Promise}
@@ -907,6 +921,19 @@ class Wallet extends EventEmitter {
 
   getBids(options) {
     return this.client.getBids(this.id, options);
+  }
+
+  /**
+   * Get wallet reveal for a given name.
+   * {@see hsd.BidReveal}
+   * @param {String?} name
+   * @param {Object?} options
+   * @param {Boolean?} options.own
+   * @returns {Promise}
+   */
+
+  getRevealsByName(name, options) {
+    return this.client.getRevealsByName(this.id, name, options);
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -355,6 +355,21 @@ class WalletClient extends Client {
   }
 
   /**
+   * Get bids, reveals and name state
+   * for all names the wallet manages.
+   * {@see hsd.NameState}
+   * {@see hsd.BlindBid}
+   * {@see hsd.BidReveal}
+   * @param {String} id
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  getAuctions(id, options) {
+    return this.get(`/wallet/${id}/auction`, options);
+  }
+
+  /**
    * @param {Number} now - Current time.
    * @param {Number} age - Age delta.
    * @returns {Promise}
@@ -824,6 +839,20 @@ class Wallet extends EventEmitter {
 
   getAuctionByName(name) {
     return this.client.getAuctionByName(this.id, name);
+  }
+
+  /**
+   * Get bids, reveals and name state
+   * for all names the wallet manages.
+   * {@see hsd.NameState}
+   * {@see hsd.BlindBid}
+   * {@see hsd.BidReveal}
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  getAuctions(options) {
+    return this.client.getAuctions(this.id, options);
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -340,6 +340,21 @@ class WalletClient extends Client {
   }
 
   /**
+   * Get bids, reveals and name state
+   * for the given name.
+   * {@see hsd.NameState}
+   * {@see hsd.BlindBid}
+   * {@see hsd.BidReveal}
+   * @param {String} id
+   * @param {String} name
+   * @returns {Promise}
+   */
+
+  getAuctionByName(id, name) {
+    return this.get(`/wallet/${id}/auction/${name}`);
+  }
+
+  /**
    * @param {Number} now - Current time.
    * @param {Number} age - Age delta.
    * @returns {Promise}
@@ -795,6 +810,20 @@ class Wallet extends EventEmitter {
 
   getNames() {
     return this.client.getNames(this.id);
+  }
+
+  /**
+   * Get bids, reveals and name state
+   * for the given name.
+   * {@see hsd.NameState}
+   * {@see hsd.BlindBid}
+   * {@see hsd.BidReveal}
+   * @param {String} name
+   * @returns {Promise}
+   */
+
+  getAuctionByName(name) {
+    return this.client.getAuctionByName(this.id, name);
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -484,6 +484,17 @@ class WalletClient extends Client {
   }
 
   /**
+   * Create open transaction.
+   * @param {String} id
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createOpen(id, options) {
+    return this.post(`/wallet/${id}/open`, options);
+  }
+
+  /**
    * Sign a transaction.
    * @param {Object} options
    * @returns {Promise}
@@ -1043,6 +1054,16 @@ class Wallet extends EventEmitter {
 
   send(options) {
     return this.client.send(this.id, options);
+  }
+
+  /**
+   * Create open transaction.
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createOpen(options) {
+    return this.client.createOpen(this.id, options);
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -517,6 +517,17 @@ class WalletClient extends Client {
   }
 
   /**
+   * Create redeem transaction.
+   * @param {String} id
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createRedeem(id, options) {
+    return this.post(`/wallet/${id}/redeem`, options);
+  }
+
+  /**
    * Sign a transaction.
    * @param {Object} options
    * @returns {Promise}
@@ -1106,6 +1117,16 @@ class Wallet extends EventEmitter {
 
   createReveal(options) {
     return this.client.createReveal(this.id, options);
+  }
+
+  /**
+   * Create redeem transaction.
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createRedeem(options) {
+    return this.client.createRedeem(this.id, options);
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -506,6 +506,17 @@ class WalletClient extends Client {
   }
 
   /**
+   * Create reveal transaction.
+   * @param {String} id
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createReveal(id, options) {
+    return this.post(`/wallet/${id}/reveal`, options);
+  }
+
+  /**
    * Sign a transaction.
    * @param {Object} options
    * @returns {Promise}
@@ -1085,6 +1096,16 @@ class Wallet extends EventEmitter {
 
   createBid(options) {
     return this.client.createBid(this.id, options);
+  }
+
+  /**
+   * Create reveal transaction.
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createReveal(options) {
+    return this.client.createReveal(this.id, options);
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -437,6 +437,20 @@ class WalletClient extends Client {
     return this.get(`/wallet/${id}/resource/${name}`);
   }
 
+  /*
+   * Deterministically regenerate a bid's nonce.
+   * @param {String} id
+   * @param {String} name
+   * @param {Object} options
+   * @param {String} options.address
+   * @param {Number} options.bid
+   * @returns {Promise}
+   */
+
+  getNonce(id, name, options) {
+    return this.get(`/wallet/${id}/nonce/${name}`, options);
+  }
+
   /**
    * @param {Number} now - Current time.
    * @param {Number} age - Age delta.
@@ -984,6 +998,19 @@ class Wallet extends EventEmitter {
 
   getResource(name) {
     return this.client.getResource(this.id, name);
+  }
+
+  /*
+   * Deterministically regenerate a bid's nonce.
+   * @param {String} name
+   * @param {Object} options
+   * @param {String} options.address
+   * @param {Number} options.bid
+   * @returns {Promise}
+   */
+
+  getNonce(name, options) {
+    return this.client.getNonce(this.id, name, options);
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -539,6 +539,17 @@ class WalletClient extends Client {
   }
 
   /**
+   * Create renewal transaction.
+   * @param {String} id
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createRenewal(id, options) {
+    return this.post(`/wallet/${id}/renewal`, options);
+  }
+
+  /**
    * Sign a transaction.
    * @param {Object} options
    * @returns {Promise}
@@ -1148,6 +1159,16 @@ class Wallet extends EventEmitter {
 
   createUpdate(options) {
     return this.client.createUpdate(this.id, options);
+  }
+
+  /**
+   * Create renewal transaction.
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createRenewal(options) {
+    return this.client.createRenewal(this.id, options);
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -328,6 +328,18 @@ class WalletClient extends Client {
   }
 
   /**
+   * Get name state for all names
+   * that the wallet is managing.
+   * {@see hsd.NameState}
+   * @param {String} id
+   * @returns {Promise}
+   */
+
+  getNames(id) {
+    return this.get(`/wallet/${id}/name`);
+  }
+
+  /**
    * @param {Number} now - Current time.
    * @param {Number} age - Age delta.
    * @returns {Promise}
@@ -772,6 +784,17 @@ class Wallet extends EventEmitter {
 
   getName(name) {
     return this.client.getName(this.id, name);
+  }
+
+  /**
+   * Get name state for all names
+   * that the wallet is managing.
+   * {@see hsd.NameState}
+   * @returns {Promise}
+   */
+
+  getNames() {
+    return this.client.getNames(this.id);
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -561,6 +561,17 @@ class WalletClient extends Client {
   }
 
   /**
+   * Create cancel transaction.
+   * @param {String} id
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createCancel(id, options) {
+    return this.post(`/wallet/${id}/cancel`, options);
+  }
+
+  /**
    * Sign a transaction.
    * @param {Object} options
    * @returns {Promise}
@@ -1190,6 +1201,16 @@ class Wallet extends EventEmitter {
 
   createTransfer(options) {
     return this.client.createTransfer(this.id, options);
+  }
+
+  /**
+   * Create cancel transaction.
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createCancel(options) {
+    return this.client.createCancel(this.id, options);
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -528,6 +528,17 @@ class WalletClient extends Client {
   }
 
   /**
+   * Create update transaction.
+   * @param {String} id
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createUpdate(id, options) {
+    return this.post(`/wallet/${id}/update`, options);
+  }
+
+  /**
    * Sign a transaction.
    * @param {Object} options
    * @returns {Promise}
@@ -1127,6 +1138,16 @@ class Wallet extends EventEmitter {
 
   createRedeem(options) {
     return this.client.createRedeem(this.id, options);
+  }
+
+  /**
+   * Create update transaction.
+   * @param {Object} options
+   * @returns {Promise}
+   */
+
+  createUpdate(options) {
+    return this.client.createUpdate(this.id, options);
   }
 
   /**

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -370,6 +370,20 @@ class WalletClient extends Client {
   }
 
   /**
+   * Get bids for a given name.
+   * {@see hsd.BlindBid}
+   * @param {String} id
+   * @param {String?} name
+   * @param {Object?} options
+   * @param {Boolean?} options.own
+   * @returns {Promise}
+   */
+
+  getBidsByName(id, name, options) {
+    return this.get(`/wallet/${id}/bid/${name}`, options);
+  }
+
+  /**
    * @param {Number} now - Current time.
    * @param {Number} age - Age delta.
    * @returns {Promise}
@@ -853,6 +867,19 @@ class Wallet extends EventEmitter {
 
   getAuctions(options) {
     return this.client.getAuctions(this.id, options);
+  }
+
+  /**
+   * Get bids for a given name.
+   * {@see hsd.BlindBid}
+   * @param {String?} name
+   * @param {Object?} options
+   * @param {Boolean?} options.own
+   * @returns {Promise}
+   */
+
+  getBidsByName(name, options) {
+    return this.client.getBidsByName(this.id, name, options);
   }
 
   /**


### PR DESCRIPTION
This PR implements the client side wrappers for https://github.com/handshake-org/hsd/pull/163/

For each new method, it is added to both the `Wallet` and the `WalletClient`, staying consistent with the way that the library currently works.

Methods Added:

- getName
- getNames
- getAuctionByName
- getAuctions
- getBidsByName
- getBids
- getRevealsByName
- getReveals
- getResource
- getNonce
- createOpen
- createBid
- createReveal
- createRedeem
- createUpdate
- createRenewal
- createTransfer
- createCancel
- createFinalize
- createRevoke

There is no CI for this library, I made sure to run `npm run lint` and have it pass