### PR TITLE
cli/client: add getnamestate and getnameresource

### DIFF
--- a/bin/hsd-cli
+++ b/bin/hsd-cli
@@ -67,10 +67,10 @@ class CLI {
   async getNameState() {
     const name = this.config.str(0, '');
 
-    const ns = await this.client.getNameState(name);
+    const ns = await this.client.execute('getnameinfo', [name]);
 
     if (!ns){
-      this.log('NameState not found.');
+      this.log('Name state not found.');
       return;
     }
 
@@ -80,10 +80,10 @@ class CLI {
   async getNameResource() {
     const name = this.config.str(0, '');
 
-    const resource = await this.client.getNameResource(name);
+    const resource = await this.client.execute('getnameresource', [name]);
 
     if (!resource){
-      this.log('Resouce not found.');
+      this.log('Resource not found.');
       return;
     }
 

--- a/bin/hsd-cli
+++ b/bin/hsd-cli
@@ -64,6 +64,32 @@ class CLI {
     this.log(info);
   }
 
+  async getNameState() {
+    const name = this.config.str(0, '');
+
+    const ns = await this.client.getNameState(name);
+
+    if (!ns){
+      this.log('NameState not found.');
+      return;
+    }
+
+    this.log(ns);
+  }
+
+  async getNameResource() {
+    const name = this.config.str(0, '');
+
+    const resource = await this.client.getNameResource(name);
+
+    if (!resource){
+      this.log('Resouce not found.');
+      return;
+    }
+
+    this.log(resource);
+  }
+
   async getTX() {
     const hash = this.config.str(0, '');
 
@@ -183,6 +209,12 @@ class CLI {
       case 'mempool':
         await this.getMempool();
         break;
+      case 'namestate':
+        await this.getNameState();
+        break;
+      case 'resource':
+        await this.getNameResource();
+        break;
       case 'tx':
         await this.getTX();
         break;
@@ -204,6 +236,8 @@ class CLI {
         this.log('  $ info: Get server info.');
         this.log('  $ broadcast [tx-hex]: Broadcast transaction.');
         this.log('  $ mempool: Get mempool snapshot.');
+        this.log('  $ namestate [name]: View NameState.');
+        this.log('  $ resource [name]: View Resource.');
         this.log('  $ tx [hash/address]: View transactions.');
         this.log('  $ coin [hash+index/address]: View coins.');
         this.log('  $ block [hash/height]: View block.');

--- a/lib/node.js
+++ b/lib/node.js
@@ -63,6 +63,26 @@ class NodeClient extends Client {
   }
 
   /**
+   * Get Name State.
+   * @returns {Promise}
+   */
+
+  getNameState(name) {
+    assert(typeof name === 'string');
+    return this.execute('getnameinfo', [name]);
+  }
+
+  /**
+   * Get Name Resource.
+   * @returns {Promise}
+   */
+
+  getNameResource(name) {
+    assert(typeof name === 'string');
+    return this.execute('getnameresource', [name]);
+  }
+
+  /**
    * Get coins that pertain to an address from the mempool or chain database.
    * Takes into account spent coins in the mempool.
    * @param {String} address

--- a/lib/node.js
+++ b/lib/node.js
@@ -63,26 +63,6 @@ class NodeClient extends Client {
   }
 
   /**
-   * Get Name State.
-   * @returns {Promise}
-   */
-
-  getNameState(name) {
-    assert(typeof name === 'string');
-    return this.execute('getnameinfo', [name]);
-  }
-
-  /**
-   * Get Name Resource.
-   * @returns {Promise}
-   */
-
-  getNameResource(name) {
-    assert(typeof name === 'string');
-    return this.execute('getnameresource', [name]);
-  }
-
-  /**
    * Get coins that pertain to an address from the mempool or chain database.
    * Takes into account spent coins in the mempool.
    * @param {String} address


### PR DESCRIPTION
This PR adds two new commands to the `hsd-cli` tool.

- `$ hsd-cli namestate [name]`
- `$ hsd-cli resource [name]`

It also adds the correct methods to the `NodeClient` so that the cli can have this functionality. I find these methods to be useful when exploring the chainstate from the cli. The methods currently wrap the RPC endpoints so it is possible to get the same functionality with `$ hsd-cli rpc ...`, but making the commands first class citizens will help to make it easier for people using the cli tool, since namestate and resources are important in Handshake. Potentially consider switching to using the HTTP endpoints once they are merged in.