### PR TITLE
bin: add timeout config option

### DIFF
--- a/bin/hsd-cli
+++ b/bin/hsd-cli
@@ -45,7 +45,8 @@ class CLI {
       host: this.config.str('http-host'),
       port: this.config.uint('http-port')
         || ports[this.network]
-        || ports.main
+        || ports.main,
+      timeout: this.config.uint('timeout')
     });
   }
 

--- a/bin/hsw-cli
+++ b/bin/hsw-cli
@@ -50,6 +50,7 @@ class CLI {
       port: this.config.uint('http-port')
         || ports[this.network]
         || ports.main,
+      timeout: this.config.uint('timeout'),
       token
     });
 


### PR DESCRIPTION
This PR exposes the timeout option to the user when using the CLI tools. There is a user running into issues where their requests are timing out, so exposing this option to them will allow them to increase their timeout.