### PR TITLE
hsd-cli: expose http limit command

### DIFF
--- a/bin/hsd-cli
+++ b/bin/hsd-cli
@@ -46,7 +46,8 @@ class CLI {
       port: this.config.uint('http-port')
         || ports[this.network]
         || ports.main,
-      timeout: this.config.uint('timeout')
+      timeout: this.config.uint('timeout'),
+      limit: this.config.uint('limit')
     });
   }
 


### PR DESCRIPTION
I was running into trouble requesting data from `hsd` and found that the `NodeClient` has a setting that puts a restriction on the max size of the response. In the [brq Request](https://github.com/bcoin-org/brq/blob/master/lib/request.js) object, there is an option called `limit`, no response can be larger than the limit.

```
    if (this.options.isOverflow(length)) {
      this.finish(new Error('Response exceeded limit.'));
      return;
    }
```
https://github.com/bcoin-org/brq/blob/534bb2c83fb366ba40ad80bc3de796a174503294/lib/request.js#L507

```
  isOverflow(hdr) {
   ... removed for brevity....

    const length = parseInt(hdr, 10);

    if (!Number.isSafeInteger(length))
      return true;

    return length > this.limit;
  }
```
https://github.com/bcoin-org/brq/blob/master/lib/request.js#L238

Passing along the `limit` param to the `NodeClient` constructor results in the `limit` value being set. The initial value of the `limit` is:

```
    this.limit = 20 << 20;
```
https://github.com/bcoin-org/brq/blob/534bb2c83fb366ba40ad80bc3de796a174503294/lib/request.js#L48