### PR TITLE
nodeclient: getblockheader

### DIFF
--- a/bin/hsd-cli
+++ b/bin/hsd-cli
@@ -96,6 +96,22 @@ class CLI {
     this.log(block);
   }
 
+  async getBlockHeader() {
+    let hash = this.config.str(0, '');
+
+    if (hash.length !== 64)
+      hash = parseInt(hash, 10);
+
+    const header = await this.client.getBlockHeader(hash);
+
+    if (!header) {
+      this.log('Block header not found.');
+      return;
+    }
+
+    this.log(header);
+  }
+
   async getCoin() {
     const hash = this.config.str(0, '');
     const index = this.config.uint(1);
@@ -189,6 +205,9 @@ class CLI {
       case 'block':
         await this.getBlock();
         break;
+      case 'header':
+        await this.getBlockHeader();
+        break;
       case 'reset':
         await this.reset();
         break;
@@ -204,6 +223,7 @@ class CLI {
         this.log('  $ tx [hash/address]: View transactions.');
         this.log('  $ coin [hash+index/address]: View coins.');
         this.log('  $ block [hash/height]: View block.');
+        this.log('  $ header [hash/height]: View block header.');
         this.log('  $ reset [height/hash]: Reset chain to desired block.');
         this.log('  $ rpc [command] [args]: Execute RPC command.');
         break;

--- a/lib/node.js
+++ b/lib/node.js
@@ -147,6 +147,17 @@ class NodeClient extends Client {
   }
 
   /**
+   * Retrieve a block header.
+   * @param {Hash|Number} block
+   * @returns {Promise}
+   */
+
+  getBlockHeader(block) {
+    assert(typeof block === 'string' || typeof block === 'number');
+    return this.get(`/header/${block}`);
+  }
+
+  /**
    * Add a transaction to the mempool and broadcast it.
    * @param {TX} tx
    * @returns {Promise}


### PR DESCRIPTION
Adds a method `getBlockHeader` to the `NodeClient`

Based on https://github.com/bcoin-org/bclient/pull/21
Requires https://github.com/handshake-org/hsd/pull/210