### PR TITLE
Add bin to linter.

### DIFF
--- a/.eslintfiles
+++ b/.eslintfiles
@@ -1,0 +1,3 @@
+lib/
+bin/hsd-cli
+bin/hsw-cli

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,0 +1,28 @@
+name: Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+
+    - uses: actions/checkout@v2
+    - name: Setup
+      uses: actions/setup-node@v1
+
+    - name: Install
+      run: npm install bslint
+
+    - name: Lint
+      run: npm run lint

--- a/bin/hsd-cli
+++ b/bin/hsd-cli
@@ -12,6 +12,23 @@ const ports = {
   simnet: 15037
 };
 
+const HELP = `
+Commands:
+  $ block [hash/height]: View block.
+  $ broadcast [tx-hex]: Broadcast transaction.
+  $ coin [hash+index/address]: View coins.
+  $ header [hash/height]: View block header.
+  $ help: Show help message.
+  $ info: Get server info.
+  $ mempool: Get mempool snapshot.
+  $ reset [height/hash]: Reset chain to desired block.
+  $ rpc [command] [args]: Execute RPC command.
+  $ tx [hash/address]: View transactions.
+
+For additional information and a complete list of commands
+visit https://hsd-dev.org/api-docs/
+`;
+
 class CLI {
   constructor() {
     this.config = new Config('hsd', {
@@ -188,26 +205,26 @@ class CLI {
 
   async open() {
     switch (this.argv.shift()) {
-      case 'info':
-        await this.getInfo();
+      case 'block':
+        await this.getBlock();
         break;
       case 'broadcast':
         await this.broadcast();
         break;
-      case 'mempool':
-        await this.getMempool();
-        break;
-      case 'tx':
-        await this.getTX();
-        break;
       case 'coin':
         await this.getCoin();
         break;
-      case 'block':
-        await this.getBlock();
-        break;
       case 'header':
         await this.getBlockHeader();
+        break;
+      case 'help':
+        process.stdout.write(HELP + '\n');
+        break;
+      case 'info':
+        await this.getInfo();
+        break;
+      case 'mempool':
+        await this.getMempool();
         break;
       case 'reset':
         await this.reset();
@@ -215,20 +232,12 @@ class CLI {
       case 'rpc':
         await this.rpc();
         break;
+      case 'tx':
+        await this.getTX();
+        break;
       default:
-        this.log('Unrecognized command.');
-
-        this.log('Commands:');
-        this.log('  $ info: Get server info.');
-        this.log('  $ broadcast [tx-hex]: Broadcast transaction.');
-        this.log('  $ mempool: Get mempool snapshot.');
-        this.log('  $ tx [hash/address]: View transactions.');
-        this.log('  $ coin [hash+index/address]: View coins.');
-        this.log('  $ block [hash/height]: View block.');
-        this.log('  $ header [hash/height]: View block header.');
-        this.log('  $ reset [height/hash]: Reset chain to desired block.');
-        this.log('  $ rpc [command] [args]: Execute RPC command.');
-        this.log('For additional information and a complete list of commands visit https://hsd-dev.org/api-docs/');
+        process.stdout.write('Unrecognized command.\n');
+        process.stdout.write(HELP + '\n');
         break;
     }
   }

--- a/bin/hsw-cli
+++ b/bin/hsw-cli
@@ -13,6 +13,63 @@ const ports = {
   simnet: 15039
 };
 
+const HELP = `
+Commands:
+  $ abandon [hash]: Abandon a transaction.
+  $ account create [account-name]: Create account.
+  $ account get [account-name]: Get account details.
+  $ account list: List account names.
+  $ address [account-name]: Derive new address.
+  $ balance: Get wallet balance.
+  $ block [height]: View wallet block.
+  $ blocks: List wallet blocks.
+  $ change [account-name]: Derive new change address.
+  $ coins: View wallet coins.
+  $ dump [address]: Get wallet key WIF by address.
+  $ get: View wallet.
+  $ help: Show help message.
+  $ history: View TX history.
+  $ import [wif|hex]: Import private or public key.
+  $ key [address]: Get wallet key by address.
+  $ listen: Listen for events.
+  $ lock: Lock wallet.
+  $ mktx [address] [value]: Create transaction.
+  $ pending: View pending TXs.
+  $ resendwallet [id]: Resend pending transactions for a single wallet.
+  $ retoken: Create new api key.
+  $ send [address] [value]: Send transaction.
+  $ shared add [account-name] [xpubkey]: Add key to account.
+  $ shared remove [account-name] [xpubkey]: Remove key from account.
+  $ shared list [account-name]: List keys in account.
+  $ sign [tx-hex]: Sign transaction.
+  $ tx [hash]: View transaction details.
+  $ unlock [passphrase] [timeout?]: Unlock wallet.
+  $ view [tx-hex]: Parse and view transaction.
+  $ watch [address]: Import an address.
+  $ zap [age]: Zap pending wallet TXs.
+
+If node is run with wallet-auth flag, then wallet commands
+require authorization token.
+Admin commands require admin permissions for provided authorization token:
+  $ backup [path]: Backup the wallet db.
+  $ master: View wallet master key.
+  $ mkwallet [id]: Create wallet.
+  $ rescan [height]: Rescan for transactions.
+  $ resend: Resend pending transactions for all wallets.
+  $ rpc [command] [args]: Execute RPC command.
+  $ wallets: List all wallets.
+
+Other options:
+  --id [wallet id]: Wallet id.
+  --passphrase [passphrase]: For signing/account-creation.
+  --account [account-name]: Account name.
+  --token [token]: Wallet-specific or admin authorization token.
+  --api-key [key]: General API authorization key.
+
+For additional information and a complete list of commands
+visit https://hsd-dev.org/api-docs/
+`;
+
 class CLI {
   constructor() {
     this.config = new Config('hsd', {
@@ -495,7 +552,7 @@ class CLI {
           await this.createAccount();
           break;
         }
-        if (this.argv[0] === 'get') 
+        if (this.argv[0] === 'get')
           this.argv.shift();
         await this.getAccount();
         break;
@@ -525,6 +582,9 @@ class CLI {
         break;
       case 'get':
         await this.getWallet();
+        break;
+      case 'help':
+        process.stdout.write(HELP + '\n');
         break;
       case 'history':
         await this.getWalletHistory();
@@ -582,7 +642,7 @@ class CLI {
           await this.removeSharedKey();
           break;
         }
-        if (this.argv[0] === 'list') 
+        if (this.argv[0] === 'list')
           this.argv.shift();
         await this.getSharedKeys();
         break;
@@ -608,58 +668,8 @@ class CLI {
         await this.zapWallet();
         break;
       default:
-        this.log('Unrecognized command.');
-        this.log('');
-        this.log('Commands:');
-        this.log('  $ abandon [hash]: Abandon a transaction.');
-        this.log('  $ account create [account-name]: Create account.');
-        this.log('  $ account get [account-name]: Get account details.');
-        this.log('  $ account list: List account names.');
-        this.log('  $ address [account-name]: Derive new address.');
-        this.log('  $ balance: Get wallet balance.');
-        this.log('  $ block [height]: View wallet block.');
-        this.log('  $ blocks: List wallet blocks.');
-        this.log('  $ change [account-name]: Derive new change address.');
-        this.log('  $ coins: View wallet coins.');
-        this.log('  $ dump [address]: Get wallet key WIF by address.');
-        this.log('  $ get: View wallet.');
-        this.log('  $ history: View TX history.');
-        this.log('  $ import [wif|hex]: Import private or public key.');
-        this.log('  $ key [address]: Get wallet key by address.');
-        this.log('  $ listen: Listen for events.');
-        this.log('  $ lock: Lock wallet.');
-        this.log('  $ mktx [address] [value]: Create transaction.');
-        this.log('  $ pending: View pending TXs.');
-        this.log('  $ resendwallet [id]: Resend pending transactions for a single wallet.');
-        this.log('  $ retoken: Create new api key.');
-        this.log('  $ send [address] [value]: Send transaction.');
-        this.log('  $ shared add [account-name] [xpubkey]: Add key to account.');
-        this.log('  $ shared remove [account-name] [xpubkey]: Remove key from account.');
-        this.log('  $ shared list [account-name]: List keys in account.');
-        this.log('  $ sign [tx-hex]: Sign transaction.');
-        this.log('  $ tx [hash]: View transaction details.');
-        this.log('  $ unlock [passphrase] [timeout?]: Unlock wallet.');
-        this.log('  $ view [tx-hex]: Parse and view transaction.');
-        this.log('  $ watch [address]: Import an address.');
-        this.log('  $ zap [age]: Zap pending wallet TXs.');
-        this.log('');
-        this.log('If node is run with wallet-auth flag, wallet commands require authorization token.');
-        this.log('Admin commands require admin permissions for provided authorization token:');
-        this.log('  $ backup [path]: Backup the wallet db.');
-        this.log('  $ master: View wallet master key.');
-        this.log('  $ mkwallet [id]: Create wallet.');
-        this.log('  $ rescan [height]: Rescan for transactions.');
-        this.log('  $ resend: Resend pending transactions for all wallets.');
-        this.log('  $ rpc [command] [args]: Execute RPC command.');
-        this.log('  $ wallets: List all wallets.');
-        this.log('');
-        this.log('Other options:');
-        this.log('  --id [wallet id]: Wallet id.');
-        this.log('  --passphrase [passphrase]: For signing/account-creation.');
-        this.log('  --account [account-name]: Account name.');
-        this.log('  --token [token]: Wallet-specific or admin authorization token.');
-        this.log('  --api-key [key]: General API authorization key.');
-        this.log('For additional information and a complete list of commands visit https://hsd-dev.org/api-docs/');
+        process.stdout.write('Unrecognized command.\n');
+        process.stdout.write(HELP + '\n');
         break;
     }
   }

--- a/lib/wallet.js
+++ b/lib/wallet.js
@@ -197,9 +197,9 @@ class WalletClient extends Client {
    */
 
   createWallet(id, options) {
-    if (id == null) {
+    if (id == null)
       throw new Error('Wallet id is required.');
-    }
+
     return this.put(`/wallet/${id}`, options);
   }
 
@@ -1325,9 +1325,9 @@ class Wallet extends EventEmitter {
    */
 
   createAccount(name, options) {
-    if (name == null) {
+    if (name == null)
       throw new Error('Account name is required.');
-    }
+
     return this.client.createAccount(this.id, name, options);
   }
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Christopher Jeffrey <chjjeffrey@gmail.com>",
   "main": "./lib/hs-client.js",
   "scripts": {
-    "lint": "eslint lib/ || exit 0",
+    "lint": "eslint $(cat .eslintfiles)",
     "test": "bmocha --reporter spec test/*-test.js"
   },
   "bin": {


### PR DESCRIPTION
This also adds `github workflow` for linting.

Notice that github workflow does not do testing and coverage, as this project doesn't/can't have tests. 
Only linting and also only uses 14.x nodejs (as there are no tests)

From commits:
 44e3b4d:
  - pkg: add bin files to linter.
  - pkg: fix lint errors.
  - bin: multiline HELP strings.
  - bin: reorder hsd-cli commands.
  - bin: add help command to hsd-cli and hsw-cli.

I believe previous one (as well as this):
 Closes: #24 