### PR TITLE
Fix doc for mkwallet

### DIFF
--- a/bin/hsw-cli
+++ b/bin/hsw-cli
@@ -34,6 +34,7 @@ Commands:
   $ listen: Listen for events.
   $ lock: Lock wallet.
   $ mktx [address] [value]: Create transaction.
+  $ mkwallet [id]: Create wallet.
   $ pending: View pending TXs.
   $ resendwallet [id]: Resend pending transactions for a single wallet.
   $ retoken: Create new api key.
@@ -53,7 +54,6 @@ require authorization token.
 Admin commands require admin permissions for provided authorization token:
   $ backup [path]: Backup the wallet db.
   $ master: View wallet master key.
-  $ mkwallet [id]: Create wallet.
   $ rescan [height]: Rescan for transactions.
   $ resend: Resend pending transactions for all wallets.
   $ rpc [command] [args]: Execute RPC command.


### PR DESCRIPTION
`mkwallet` in the wallet is non-admin command and before we decide to rework API of the wallet will be the same.

Small summary:  
hsw-wallet is not meant to be exposed publicly other than using it internally, it's not ready for that and is not designed with that idea in mind. It would need a lot more work if we ever wanted to make it publicly exposable service.

Related: https://github.com/handshake-org/hsd/pull/581