### PR TITLE
bin: replace shell scripts with js require

### DIFF
--- a/bin/hsd-cli
+++ b/bin/hsd-cli
@@ -253,11 +253,17 @@ class CLI {
   }
 }
 
-(async () => {
-  const cli = new CLI();
-  await cli.open();
-  await cli.destroy();
-})().catch((err) => {
-  console.error(err.stack);
-  process.exit(1);
-});
+if (require.main === module) {
+  // cli, not a require
+
+  (async () => {
+    const cli = new CLI();
+    await cli.open();
+    await cli.destroy();
+  })().catch((err) => {
+    console.error(err.stack);
+    process.exit(1);
+  });
+}
+
+module.exports = CLI;

--- a/bin/hsd-rpc
+++ b/bin/hsd-rpc
@@ -1,21 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env node
 
-rl=0
+const CLI = require('./hsd-cli');
 
-if ! type perl > /dev/null 2>& 1; then
-  if uname | grep -i 'darwin' > /dev/null; then
-    echo 'hsd-rpc requires perl to start on OSX.' >& 2
-    exit 1
-  fi
-  rl=1
-fi
-
-if test $rl -eq 1; then
-  file=$(readlink -f "$0")
-else
-  file=$(perl -MCwd -e "print Cwd::realpath('$0')")
-fi
-
-dir=$(dirname "$file")
-
-exec "${dir}/hsd-cli" rpc "$@"
+(async () => {
+  const cli = new CLI();
+  await cli.rpc();
+  await cli.destroy();
+})().catch((err) => {
+  console.error(err.stack);
+  process.exit(1);
+});

--- a/bin/hsw-cli
+++ b/bin/hsw-cli
@@ -686,11 +686,17 @@ class CLI {
   }
 }
 
-(async () => {
-  const cli = new CLI();
-  await cli.handleWallet();
-  await cli.destroy();
-})().catch((err) => {
-  console.error(err.stack);
-  process.exit(1);
-});
+if (require.main === module) {
+  // cli, not a require
+
+  (async () => {
+    const cli = new CLI();
+    await cli.handleWallet();
+    await cli.destroy();
+  })().catch((err) => {
+    console.error(err.stack);
+    process.exit(1);
+  });
+}
+
+module.exports = CLI;

--- a/bin/hsw-rpc
+++ b/bin/hsw-rpc
@@ -1,21 +1,12 @@
-#!/bin/sh
+#!/usr/bin/env node
 
-rl=0
+const CLI = require('./hsw-cli');
 
-if ! type perl > /dev/null 2>& 1; then
-  if uname | grep -i 'darwin' > /dev/null; then
-    echo 'hsw-rpc requires perl to start on OSX.' >& 2
-    exit 1
-  fi
-  rl=1
-fi
-
-if test $rl -eq 1; then
-  file=$(readlink -f "$0")
-else
-  file=$(perl -MCwd -e "print Cwd::realpath('$0')")
-fi
-
-dir=$(dirname "$file")
-
-exec "${dir}/hsw-cli" rpc "$@"
+(async () => {
+  const cli = new CLI();
+  await cli.rpc();
+  await cli.destroy();
+})().catch((err) => {
+  console.error(err.stack);
+  process.exit(1);
+});


### PR DESCRIPTION
`hs{d,w}-rpc` scripts are currently shell scripts and depend on perl on macos.
This replaces them with simpler js `require`s.
It's a breaking change since `CLI.open()` / `CLI.handleWallet()` are only called when run as a script, not `require`d. This way the CLI class can be required by other scripts.

This has a sibling PR on hsd:
- https://github.com/handshake-org/hsd/pull/746

I did think of simply rewriting the shell script and calling nodejs again with `child_process` exec or something, but this seems cleaner without leaving the current process, even if it means a bit of change to hsd.

If `child_process` is still preferred, I'll change it to that.