### PR TITLE
Add lookahead to mkwallet and account create.

### DIFF
--- a/bin/hsw-cli
+++ b/bin/hsw-cli
@@ -140,6 +140,7 @@ class CLI {
       bip39Passphrase: this.config.str('bip39Passphrase'),
       watchOnly: this.config.has('key') ? true : this.config.bool('watch'),
       accountKey: this.config.str('key'),
+      loookahead: this.config.uint('lookahead'),
       language: this.config.str('language')
     };
 
@@ -219,7 +220,8 @@ class CLI {
       m: this.config.uint('m'),
       n: this.config.uint('n'),
       witness: this.config.bool('witness'),
-      accountKey: this.config.str('key')
+      accountKey: this.config.str('key'),
+      lookahead: this.config.uint('lookahead')
     };
 
     const account = await this.wallet.createAccount(name, options);


### PR DESCRIPTION
New HSD will support account lookahead configurations up to 2^32 - 1. So this will allow the hsw to send lookahead.

https://github.com/handshake-org/hsd/pull/769