### PR TITLE
bin: fix config aliases for http-{host,port}

### DIFF
--- a/bin/hsd-cli
+++ b/bin/hsd-cli
@@ -40,8 +40,8 @@ class CLI {
         'uri': 'url',
         'k': 'api-key',
         's': 'ssl',
-        'h': 'httphost',
-        'p': 'httpport'
+        'h': 'http-host',
+        'p': 'http-port'
       }
     });
 

--- a/bin/hsw-cli
+++ b/bin/hsw-cli
@@ -82,8 +82,8 @@ class CLI {
         'uri': 'url',
         'k': 'api-key',
         's': 'ssl',
-        'h': 'httphost',
-        'p': 'httpport'
+        'h': 'http-host',
+        'p': 'http-port'
       }
     });
 


### PR DESCRIPTION
```
❯ hsd --memory --network regtest --http-port 4444
[info] (node-http) Node HTTP server listening on 127.0.0.1 (port=4444).

❯ hsd --memory --network regtest -p 4444
[info] (node-http) Node HTTP server listening on 127.0.0.1 (port=14037).
```